### PR TITLE
Add support for haml preprocessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,4 @@ vue-jest compiles the script and template of SFCs into a JavaScript file that Je
 
 - **pug** (`lang="pug"`)
 - **jade** (`lang="jade"`)
+- **haml** (`lang="haml"`)

--- a/lib/compilers/haml-compiler.js
+++ b/lib/compilers/haml-compiler.js
@@ -1,0 +1,14 @@
+var ensureRequire = require('../ensure-require.js')
+const throwError = require('../throw-error')
+
+module.exports = function (raw) {
+  var html
+  ensureRequire('hamljs', 'hamljs')
+  var haml = require('hamljs')
+  try {
+    html = haml.render(raw)
+  } catch (err) {
+    throwError(err)
+  }
+  return html
+}

--- a/lib/template-compiler.js
+++ b/lib/template-compiler.js
@@ -3,6 +3,7 @@ var vueCompiler = require('vue-template-compiler')
 var transpile = require('vue-template-es2015-compiler')
 var compilePug = require('./compilers/pug-compiler')
 var compileJade = require('./compilers/jade-compiler')
+var compileHaml = require('./compilers/haml-compiler')
 const throwError = require('./throw-error')
 
 function getTemplateContent (templatePart) {
@@ -11,6 +12,9 @@ function getTemplateContent (templatePart) {
   }
   if (templatePart.lang === 'jade') {
     return compileJade(templatePart.content)
+  }
+  if (templatePart.lang === 'haml') {
+    return compileHaml(templatePart.content)
   }
   return templatePart.content
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2471,6 +2471,12 @@
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
     },
+    "hamljs": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/hamljs/-/hamljs-0.6.2.tgz",
+      "integrity": "sha1-e3EWz22+cnjkKz9u+HJaM+F3yOM=",
+      "dev": true
+    },
     "handlebars": {
       "version": "4.0.11",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
@@ -5623,7 +5629,7 @@
       "integrity": "sha512-x3LV3wdmmERhVCYy3quqA57NJW7F3i6faas++pJQWtknWT+n7k30F4TVdHvCLn48peTJFRvCpxs3UuFPqgeELg=="
     },
     "vue-test-utils": {
-      "version": "git+https://github.com/vuejs/vue-test-utils.git#25f3fb43b3d5ea9e8d59012077660d946ea46d43",
+      "version": "git+https://github.com/vuejs/vue-test-utils.git#9fc11207615e399e13969c2b8cffdb6111b8d95d",
       "dev": true,
       "requires": {
         "lodash": "4.17.4",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "eslint-plugin-html": "^3.1.1",
     "eslint-plugin-vue": "^2.1.0",
     "eslint-plugin-vue-libs": "^1.2.0",
+    "hamljs": "^0.6.2",
     "jade": "^1.11.0",
     "jest": "^20.0.4",
     "pug": "^2.0.0-rc.3",


### PR DESCRIPTION
Hi!

In a recent project I'm involved to use [Haml.js](https://github.com/tj/haml.js) as templating preprocessor for my `*.vue` files.

Here's a PR that enable support for it to pass the rendered template content to Jest.

Thanks.