### PR TITLE
deprecated: replace coffee-script with coffeescript

### DIFF
--- a/lib/compilers/coffee-compiler.js
+++ b/lib/compilers/coffee-compiler.js
@@ -2,8 +2,8 @@ var ensureRequire = require('../ensure-require.js')
 const throwError = require('../throw-error')
 
 module.exports = function (raw, cb, compiler) {
-  ensureRequire('coffee', ['coffee-script'])
-  var coffee = require('coffee-script')
+  ensureRequire('coffee', ['coffeescript'])
+  var coffee = require('coffeescript')
   var compiled
   try {
     compiled = coffee.compile(raw, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1262,10 +1262,10 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
-    "coffee-script": {
-      "version": "1.12.7",
-      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
-      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
+    "coffeescript": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.0.3.tgz",
+      "integrity": "sha512-iIfUN+71IyI2FQABXh1luzZeQgqwUPeWh6lDovJatQQs+30bvyGnBY0r4BnD0hoMAasNuZVHlL1U09Oy1ZfSeg==",
       "dev": true
     },
     "color-convert": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "babel-jest": "^20.0.3",
     "babel-plugin-istanbul": "^4.1.4",
     "clear-module": "^2.1.0",
-    "coffee-script": "^1.12.7",
+    "coffeescript": "^2.0.3",
     "conventional-changelog": "^1.1.5",
     "eslint": "^4.3.0",
     "eslint-plugin-html": "^3.1.1",


### PR DESCRIPTION
coffee-script is deprecated. They recommend using coffeescipt instead.
Please see npm:
https://www.npmjs.com/package/coffee-script

Please also see this commit: https://github.com/jashkenas/coffeescript/commit/8ec10fa8ce9138db220844af31d9826660660513

Thanks,