### PR TITLE
Transpile coffeescript written in ES6

### DIFF
--- a/lib/compilers/babel-compiler.js
+++ b/lib/compilers/babel-compiler.js
@@ -1,26 +1,5 @@
 const babel = require('babel-core')
-const findBabelConfig = require('find-babel-config')
-const logger = require('../logger')
-const cache = require('../cache')
-
-var defaultBabelOptions = {
-  presets: [require.resolve('babel-preset-vue-app')]
-}
-
-function getBabelConfig () {
-  const cachedConfig = cache.get('babel-config')
-  if (cachedConfig) {
-    return cachedConfig
-  } else {
-    const { file, config } = findBabelConfig.sync(process.cwd(), 0)
-    if (!file) {
-      logger.info('no .babelrc found, defaulting to default babel options')
-    }
-    const babelConfig = file ? config : defaultBabelOptions
-    cache.set('babel-config', babelConfig)
-    return babelConfig
-  }
-}
+const loadBabelConfig = require('../load-babel-config.js')
 
 module.exports = function compileBabel (scriptContent, inputSourceMap) {
   const sourceMapOptions = {
@@ -28,9 +7,7 @@ module.exports = function compileBabel (scriptContent, inputSourceMap) {
     inputSourceMap: inputSourceMap
   }
 
-  const babelConfig = getBabelConfig()
-
-  const babelOptions = Object.assign(sourceMapOptions, babelConfig)
+  const babelOptions = Object.assign(sourceMapOptions, loadBabelConfig())
 
   const res = babel.transform(scriptContent, babelOptions)
 

--- a/lib/compilers/coffee-compiler.js
+++ b/lib/compilers/coffee-compiler.js
@@ -1,5 +1,6 @@
 var ensureRequire = require('../ensure-require.js')
 const throwError = require('../throw-error')
+const loadBabelConfig = require('../load-babel-config.js')
 
 module.exports = function (raw, cb, compiler) {
   ensureRequire('coffee', ['coffeescript'])
@@ -9,9 +10,7 @@ module.exports = function (raw, cb, compiler) {
     compiled = coffee.compile(raw, {
       bare: true,
       sourceMap: true,
-      transpile: {
-        presets: ['env']
-      }
+      transpile: loadBabelConfig()
     })
   } catch (err) {
     throwError(err)

--- a/lib/compilers/coffee-compiler.js
+++ b/lib/compilers/coffee-compiler.js
@@ -8,7 +8,10 @@ module.exports = function (raw, cb, compiler) {
   try {
     compiled = coffee.compile(raw, {
       bare: true,
-      sourceMap: true
+      sourceMap: true,
+      transpile: {
+        presets: ['env']
+      }
     })
   } catch (err) {
     throwError(err)

--- a/lib/load-babel-config.js
+++ b/lib/load-babel-config.js
@@ -1,0 +1,22 @@
+const findBabelConfig = require('find-babel-config')
+const logger = require('./logger')
+const cache = require('./cache')
+
+var defaultBabelOptions = {
+  presets: [require.resolve('babel-preset-vue-app')]
+}
+
+module.exports = function getBabelConfig () {
+  const cachedConfig = cache.get('babel-config')
+  if (cachedConfig) {
+    return cachedConfig
+  } else {
+    const { file, config } = findBabelConfig.sync(process.cwd(), 0)
+    if (!file) {
+      logger.info('no .babelrc found, defaulting to default babel options')
+    }
+    const babelConfig = file ? config : defaultBabelOptions
+    cache.set('babel-config', babelConfig)
+    return babelConfig
+  }
+}

--- a/test/coffee.spec.js
+++ b/test/coffee.spec.js
@@ -91,11 +91,4 @@ describe('Test CoffeeScript - coffee.spec.js', () => {
     // coverageData.hash is added by babel-plugin-istanbul, added to root .babelrc for this test only
     expect(output.code).toContain('coverageData.hash')
   })
-
-  test('generates inline sourcemap for coffeescript', () => {
-    const filePath = resolve(__dirname, './resources/CoffeeScriptES6.vue')
-    const fileString = readFileSync(filePath, { encoding: 'utf8' })
-    const output = jestVue.process(fileString, filePath)
-    expect(output.map).toMatchSnapshot()
-  })
 })

--- a/test/coffee.spec.js
+++ b/test/coffee.spec.js
@@ -1,21 +1,101 @@
-import { shallow } from 'vue-test-utils'
+import { shallow, mount } from 'vue-test-utils'
 import Coffee from './resources/Coffee.vue'
 import CoffeeScript from './resources/CoffeeScript.vue'
 import CoffeeES6 from './resources/CoffeeES6.vue'
 import CoffeeScriptES6 from './resources/CoffeeScriptES6.vue'
+import jestVue from '../vue-jest'
+import { resolve } from 'path'
+import {
+  readFileSync,
+  writeFileSync,
+  renameSync
+} from 'fs'
+import clearModule from 'clear-module'
+import cache from '../lib/cache'
 
-test('processes .vue file with lang set to coffeescript', () => {
-  shallow(Coffee)
-})
+describe('Test CoffeeScript - coffee.spec.js', () => {
+  beforeEach(() => {
+    cache.flushAll()
+    clearModule.all()
+  })
 
-test('processes .vue file with lang set to coffeescript', () => {
-  shallow(CoffeeScript)
-})
+  test('processes .vue file with lang set to coffee', () => {
+    shallow(Coffee)
+  })
 
-test('processes .vue file with lang set to coffeescript', () => {
-  shallow(CoffeeES6)
-})
+  test('processes .vue file with lang set to coffeescript', () => {
+    shallow(CoffeeScript)
+  })
 
-test('processes .vue file with lang set to coffeescript', () => {
-  shallow(CoffeeScriptES6)
+  test('processes .vue file with lang set to coffee (ES6)', () => {
+    shallow(CoffeeES6)
+  })
+
+  test('processes .vue file with lang set to coffeescript (ES6)', () => {
+    shallow(CoffeeScriptES6)
+  })
+
+  test('processes .vue file with lang set to coffeescript (ES6)', () => {
+    const wrapper = mount(CoffeeScriptES6)
+    expect(typeof wrapper).toBe('object')
+  })
+
+  test('processes .vue files with lang set to coffeescript using .babelrc if there is no .babelrc', () => {
+    const babelRcPath = resolve(__dirname, '../.babelrc')
+    const tempPath = resolve(__dirname, '../.renamed')
+    renameSync(babelRcPath, tempPath)
+    const filePath = resolve(__dirname, './resources/CoffeeScriptES6.vue')
+    const fileString = readFileSync(filePath, { encoding: 'utf8' })
+    try {
+      jestVue.process(fileString, filePath)
+    } catch (err) {
+      renameSync(tempPath, babelRcPath)
+      throw err
+    }
+    renameSync(tempPath, babelRcPath)
+  })
+
+  test('processes .vue files with lang set to coffeescript, uses babelrc in package.json if none in .babelrc', () => {
+    const babelRcPath = resolve(__dirname, '../.babelrc')
+    const tempPath = resolve(__dirname, '../.renamed')
+    const packagePath = resolve(__dirname, '../package.json')
+    const packageOriginal = readFileSync(packagePath, { encoding: 'utf8' })
+    writeFileSync(packagePath, '{ "babel": {"presets": ["env"],"plugins": ["istanbul"]}}')
+    renameSync(babelRcPath, tempPath)
+    const filePath = resolve(__dirname, './resources/CoffeeScriptES6.vue')
+    const fileString = readFileSync(filePath, { encoding: 'utf8' })
+
+    try {
+      const output = jestVue.process(fileString, filePath)
+      expect(output.code).toContain('coverageData.hash')
+    } catch (err) {
+      renameSync(tempPath, babelRcPath)
+      writeFileSync(packagePath, packageOriginal)
+      jest.resetModules()
+      throw err
+    }
+    renameSync(tempPath, babelRcPath)
+    writeFileSync(packagePath, packageOriginal)
+    jest.resetModules()
+  })
+
+  test('processes .vue files with lang set to coffeescript using .babelrc if it exists in route', () => {
+    const babelRcPath = resolve(__dirname, '../.babelrc')
+    const babelRcOriginal = readFileSync(babelRcPath, { encoding: 'utf8' })
+    writeFileSync(babelRcPath, '{"presets": ["env"],"plugins": ["istanbul"]}')
+    const filePath = resolve(__dirname, './resources/CoffeeScriptES6.vue')
+    const fileString = readFileSync(filePath, { encoding: 'utf8' })
+
+    const output = jestVue.process(fileString, filePath)
+    writeFileSync(babelRcPath, babelRcOriginal)
+    // coverageData.hash is added by babel-plugin-istanbul, added to root .babelrc for this test only
+    expect(output.code).toContain('coverageData.hash')
+  })
+
+  test('generates inline sourcemap for coffeescript', () => {
+    const filePath = resolve(__dirname, './resources/CoffeeScriptES6.vue')
+    const fileString = readFileSync(filePath, { encoding: 'utf8' })
+    const output = jestVue.process(fileString, filePath)
+    expect(output.map).toMatchSnapshot()
+  })
 })

--- a/test/coffee.spec.js
+++ b/test/coffee.spec.js
@@ -1,6 +1,8 @@
 import { shallow } from 'vue-test-utils'
 import Coffee from './resources/Coffee.vue'
 import CoffeeScript from './resources/CoffeeScript.vue'
+import CoffeeES6 from './resources/CoffeeES6.vue'
+import CoffeeScriptES6 from './resources/CoffeeScriptES6.vue'
 
 test('processes .vue file with lang set to coffeescript', () => {
   shallow(Coffee)
@@ -8,4 +10,12 @@ test('processes .vue file with lang set to coffeescript', () => {
 
 test('processes .vue file with lang set to coffeescript', () => {
   shallow(CoffeeScript)
+})
+
+test('processes .vue file with lang set to coffeescript', () => {
+  shallow(CoffeeES6)
+})
+
+test('processes .vue file with lang set to coffeescript', () => {
+  shallow(CoffeeScriptES6)
 })

--- a/test/load-babel-config.spec.js
+++ b/test/load-babel-config.spec.js
@@ -1,0 +1,54 @@
+import loadBabelConfig from '../lib/load-babel-config'
+import { resolve } from 'path'
+import {
+//   writeFileSync,
+  copyFileSync,
+  readFileSync,
+  renameSync
+} from 'fs'
+import clearModule from 'clear-module'
+import cache from '../lib/cache'
+
+describe('load-babel-config.js', () => {
+  beforeEach(() => {
+    cache.flushAll()
+    clearModule.all()
+  })
+
+  it('reads default babel if there is no .babelrc', () => {
+    const babelRcPath = resolve(__dirname, '../.babelrc')
+    const babelRcOriginal = JSON.parse(readFileSync(babelRcPath, { encoding: 'utf8' }))
+    const tempPath = resolve(__dirname, '../.renamed')
+    renameSync(babelRcPath, tempPath)
+    const babelConfig = loadBabelConfig()
+    try {
+      expect(babelConfig).not.toBe(babelRcOriginal)
+    } catch (err) {
+      renameSync(tempPath, babelRcPath)
+      throw err
+    }
+    renameSync(tempPath, babelRcPath)
+    const babelConfigCached = loadBabelConfig()
+    expect(babelConfigCached).not.toBe(babelConfig)
+    expect(babelConfigCached).toEqual(babelConfig)
+  })
+
+  it('reads default babel if there is .babelrc', () => {
+    const babelRcPath = resolve(__dirname, '../.babelrc')
+    const babelRcCopiedPath = resolve(__dirname, '../.babelrc_cp')
+    copyFileSync(babelRcPath, babelRcCopiedPath)
+    const babelRcOriginal = JSON.parse(readFileSync(babelRcPath, { encoding: 'utf8' }))
+    const babelConfig = loadBabelConfig()
+    expect(babelConfig).toEqual(babelRcOriginal)
+    const tempPath = resolve(__dirname, '../.renamed')
+    renameSync(babelRcCopiedPath, tempPath)
+    const babelConfigCached = loadBabelConfig()
+    try {
+      expect(babelConfig).not.toBe(babelConfigCached)
+      expect(babelConfig).toEqual(babelConfigCached)
+    } catch (err) {
+      renameSync(tempPath, babelRcCopiedPath)
+      throw err
+    }
+  })
+})

--- a/test/load-babel-config.spec.js
+++ b/test/load-babel-config.spec.js
@@ -1,8 +1,8 @@
 import loadBabelConfig from '../lib/load-babel-config'
 import { resolve } from 'path'
 import {
-//   writeFileSync,
-  copyFileSync,
+  createReadStream,
+  createWriteStream,
   readFileSync,
   renameSync
 } from 'fs'
@@ -36,7 +36,7 @@ describe('load-babel-config.js', () => {
   it('reads default babel if there is .babelrc', () => {
     const babelRcPath = resolve(__dirname, '../.babelrc')
     const babelRcCopiedPath = resolve(__dirname, '../.babelrc_cp')
-    copyFileSync(babelRcPath, babelRcCopiedPath)
+    createReadStream(babelRcPath).pipe(createWriteStream(babelRcCopiedPath))
     const babelRcOriginal = JSON.parse(readFileSync(babelRcPath, { encoding: 'utf8' }))
     const babelConfig = loadBabelConfig()
     expect(babelConfig).toEqual(babelRcOriginal)

--- a/test/resources/CoffeeES6.vue
+++ b/test/resources/CoffeeES6.vue
@@ -1,0 +1,8 @@
+<template>
+  <div />
+</template>
+
+<script lang="coffee">
+export default
+    data: -> {}
+</script>

--- a/test/resources/CoffeeScriptES6.vue
+++ b/test/resources/CoffeeScriptES6.vue
@@ -1,0 +1,8 @@
+<template>
+  <div />
+</template>
+
+<script lang="coffeescript">
+export default
+    data: -> {}
+</script>


### PR DESCRIPTION
`coffeescript` can adopt babel as a transpiler. `transpile` is the way how they set transpiler.

Please see http://coffeescript.org/#transpilation

This allows you to have vue files which adopt coffee/coffeescript (ES6) as `lang`.
I added tests and vue files.